### PR TITLE
Added support for a ctx parameter to be passed into the RX callback.

### DIFF
--- a/src/can2040.c
+++ b/src/can2040.c
@@ -691,14 +691,14 @@ static void
 report_callback_error(struct can2040 *cd, uint32_t error_code)
 {
     struct can2040_msg msg = {};
-    cd->rx_cb(cd, CAN2040_NOTIFY_ERROR | error_code, &msg);
+    cd->rx_cb(cd, CAN2040_NOTIFY_ERROR | error_code, &msg, cd->rx_cb_data);
 }
 
 // Report a received message to calling code (via callback interface)
 static void
 report_callback_rx_msg(struct can2040 *cd)
 {
-    cd->rx_cb(cd, CAN2040_NOTIFY_RX, &cd->parse_msg);
+    cd->rx_cb(cd, CAN2040_NOTIFY_RX, &cd->parse_msg, cd->rx_cb_data);
 }
 
 // Report a message that was successfully transmited (via callback interface)
@@ -706,7 +706,7 @@ static void
 report_callback_tx_msg(struct can2040 *cd)
 {
     cd->tx_pull_pos++;
-    cd->rx_cb(cd, CAN2040_NOTIFY_TX, &cd->parse_msg);
+    cd->rx_cb(cd, CAN2040_NOTIFY_TX, &cd->parse_msg, cd->rx_cb_data);
 }
 
 // EOF phase complete - report message (rx or tx) to calling code
@@ -1243,9 +1243,10 @@ can2040_setup(struct can2040 *cd, uint32_t pio_num)
 
 // API function to configure callback
 void
-can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb)
+can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb, void * rx_cb_context_data)
 {
     cd->rx_cb = rx_cb;
+    cd->rx_cb_data = rx_cb_context_data;
 }
 
 // API function to start CANbus interface

--- a/src/can2040.h
+++ b/src/can2040.h
@@ -24,7 +24,7 @@ enum {
 };
 struct can2040;
 typedef void (*can2040_rx_cb)(struct can2040 *cd, uint32_t notify
-                              , struct can2040_msg *msg);
+                              , struct can2040_msg *msg, void *ctx_data);
 
 void can2040_setup(struct can2040 *cd, uint32_t pio_num);
 void can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb);
@@ -56,6 +56,7 @@ struct can2040 {
     void *pio_hw;
     uint32_t gpio_rx, gpio_tx;
     can2040_rx_cb rx_cb;
+    void * rx_cb_data;
 
     // Bit unstuffing
     struct can2040_bitunstuffer unstuf;


### PR DESCRIPTION
Hello,
This pull request is an attempt to allow for better memory management schemes when using this library.

The goal of the context data pointer is to allow the programmer to keep state or configuration data without needing to use globals. This solves some implementation problems which arise from using both PIOs since the current configuration makes it difficult to use one rx_cb on both concurrently. 

Since this is a breaking API change, an alternate option would be to document how to allocate the `struct can2040` at the start of a meta struct containing user data. This technique is usually considered to be advanced and error prone, so it is usually frowned upon. 
