### PR TITLE
Restore stuffed_bits state on missing ack

### DIFF
--- a/src/can2040.h
+++ b/src/can2040.h
@@ -63,12 +63,11 @@ struct can2040 {
 
     // Input data state
     uint32_t parse_state;
-    uint32_t parse_crc;
+    uint32_t parse_crc, parse_crc_bits, parse_crc_pos;
     struct can2040_msg parse_msg;
 
     // Reporting
     uint32_t report_state;
-    uint32_t report_eof_key;
 
     // Transmits
     uint32_t tx_state;


### PR DESCRIPTION
As reported in #14, the internal can2040 parsing state may alter the internal `stuffed_bits` state and thus not be able to properly detect the next SOF on a missing ack.  This fixes the issue by restoring the internal `stuffed_bits` state should a missing ack be detected.

-Kevin