### PR TITLE
Don't resychronize transmit bit timing

### DIFF
--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -26,8 +26,8 @@ bus nodes that have a slightly different clock rate.  That is, the
 sampling time for each transmitted bit is adjusted to account for a
 slightly faster or slower bitrate of the transmitter.  The PIO "sync"
 state machine raises a "sample" irq (pio irq 4) at each sampling point
-and the other state machines only read the "CAN rx" line after
-receiving that signal.
+and other state machines read the "CAN rx" line after receiving that
+signal.
 
 A secondary task of the PIO "sync" state machine is to detect when a
 new transmission may start.  It will raise a "maytx" irq (pio irq 0)
@@ -76,9 +76,9 @@ used.
 
 The main task of the PIO "tx" state machine is to transmit messages on
 the "CAN tx" line.  For each bit to be transmitted, the state machine
-sets the tx line, reads the "CAN rx" line (after a "sample" irq), and
-will stop a transmission if a dominant/passive bit conflict is found.
-This enables transmissions to properly participate in CAN bus line
+sets the tx line, reads the "CAN rx" line, and will stop a
+transmission if a dominant/passive bit conflict is found.  This
+enables transmissions to properly participate in CAN bus line
 arbitration.  To transmit a message, the ARM core fills the tx fifo
 with the raw bits of the message and arranges for the "tx" state
 machine to start after a "maytx" irq.

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -81,7 +81,10 @@ transmission if a dominant/passive bit conflict is found.  This
 enables transmissions to properly participate in CAN bus line
 arbitration.  To transmit a message, the ARM core fills the tx fifo
 with the raw bits of the message and arranges for the "tx" state
-machine to start after a "maytx" irq.
+machine to start after a "maytx" irq.  The "tx" state machine performs
+its own bit time synchronization to resynchronize bit timing to other
+simultaneous transmitters that may be transmitting at a slightly
+faster bit rate.
 
 A secondary task of the PIO "tx" state machine is to inject an ack bit
 to acknowledge messages received from other CAN bus nodes.  To perform

--- a/pio/can2040.pio
+++ b/pio/can2040.pio
@@ -18,22 +18,22 @@
 
 // State machine "sync" code - clock and start/end of message signaling
 sync_recessive_edge:
-    jmp y--, sync_scan_edge     ; cp=31,33,35
-    jmp x--, sync_signal_sample ; cp=4
+    jmp y--, sync_scan_edge     ; cp=31,33,35,37
+    jmp x--, sync_signal_sample ; cp=6
 public sync_found_end_of_message:
-    set x, 10              [1]  ; cp=5
+    set x, 8               [1]  ; cp=7
 sync_loop_end_of_message:
     jmp pin sync_check_idle
 public sync_signal_start:
     irq set 0
 sync_scan_edge:
-    jmp pin sync_recessive_edge ; cp=30,32,34
+    jmp pin sync_recessive_edge ; cp=30,32,34,36
 public sync_entry:
     irq clear 0                 ; cp=1
 sync_got_dominant:
-    set x, 9               [2]  ; cp=2
+    set x, 9               [4]  ; cp=2
 sync_signal_sample:
-    set y, 2               [18] ; cp=5
+    set y, 3               [16] ; cp=7
     irq set 4              [1]  ; cp=24
     jmp pin sync_scan_edge [3]  ; cp=26
     jmp sync_got_dominant  [3]  ; cp=30
@@ -85,7 +85,7 @@ public tx_conflict:
 // Setup for "sync" state machine
 .program sm_sync_setup
     set pindirs, 0
-    // CPU pushes 106 into tx fifo - to set OSR for alternative slow start mode
+    // CPU pushes 104 into tx fifo - to set OSR for alternative slow start mode
     pull
     ;jmp sync_got_dominant
 
@@ -149,7 +149,7 @@ sync_signal_sample:
     jmp sync_got_dominant
 
 sync_scan_edge:
-    set y, 2
+    set y, 3
 sync_loop_scan_edge:
     jmp pin sync_recessive_edge
     jmp sync_got_dominant
@@ -159,7 +159,7 @@ sync_recessive_edge:
     jmp sync_found_end_of_message
 
 sync_found_end_of_message:
-    set x, 10
+    set x, 8
 sync_loop_end_of_message:
     jmp pin sync_check_idle
     jmp sync_signal_start

--- a/pio/can2040.pio
+++ b/pio/can2040.pio
@@ -71,9 +71,8 @@ public tx_got_recessive:
     nop                    [2]  ; cp=27
 public tx_start:
     out x, 1                    ; cp=30
-    mov pins, x                 ; cp=31
-    wait 1 irq 4
-    jmp pin tx_got_recessive    ; cp=26
+    mov pins, x            [20] ; cp=31
+    jmp pin tx_got_recessive [6]; cp=20
     jmp !x tx_start        [2]  ; cp=27
 public tx_conflict:
     jmp tx_conflict

--- a/pio/can2040.pio
+++ b/pio/can2040.pio
@@ -21,7 +21,7 @@ sync_recessive_edge:
     jmp y--, sync_scan_edge     ; cp=31,33,35,37
     jmp x--, sync_signal_sample ; cp=6
 public sync_found_end_of_message:
-    set x, 8               [1]  ; cp=7
+    set x, 9                    ; cp=7
 sync_loop_end_of_message:
     jmp pin sync_check_idle
 public sync_signal_start:
@@ -51,9 +51,9 @@ public shared_rx_end:
 
 // State machine "match" code - raise "matched" signal on a raw bitstream match
     mov y, isr                  ; cp=27
-    jmp x!=y match_load_next    ; cp=28
+    jmp x!=y match_load_next [1]; cp=28
 match_signal:
-    irq set 2                   ; cp=29
+    irq set 2                   ; cp=30
 public match_load_next:
     in osr, 11                  ; load next_counter and bits into isr
     in y, 20
@@ -62,20 +62,22 @@ match_check_next:
     pull noblock                ; reload target_compare into x
     mov x, osr
     jmp y-- f2                  ; setup next_counter
+public tx_conflict:
  f2:mov osr, y
 public match_end:
     ;jmp shared_rx_read         ; wrap based jump
 
 // State machine "tx" code - write messages to bus
 public tx_got_recessive:
-    nop                    [2]  ; cp=27
-public tx_start:
-    out x, 1                    ; cp=30
-    mov pins, x            [20] ; cp=31
-    jmp pin tx_got_recessive [6]; cp=20
-    jmp !x tx_start        [2]  ; cp=27
-public tx_conflict:
-    jmp tx_conflict
+    out x, 1                    ; cp=27
+    jmp pin tx_align            ; cp=28
+public tx_write_pin:
+    mov pins, x            [24] ; cp=31
+    jmp pin tx_got_recessive [2]; cp=24
+    jmp x-- tx_conflict         ; cp=27 On conflict, spin forever on dummy insn
+    out x, 1                    ; cp=28
+tx_align:
+    jmp tx_write_pin       [1]  ; cp=29
 
 
 //
@@ -85,7 +87,7 @@ public tx_conflict:
 // Setup for "sync" state machine
 .program sm_sync_setup
     set pindirs, 0
-    // CPU pushes 104 into tx fifo - to set OSR for alternative slow start mode
+    // CPU pushes 105 into tx fifo - to set OSR for alternative slow start mode
     pull
     ;jmp sync_got_dominant
 
@@ -115,7 +117,8 @@ public tx_conflict:
     // CPU clears irq 2 and irq 3
     // CPU then loads tx fifos with full (bitstuffed) message
     set pins, 1
-    ;jmp tx_start
+    out x, 1
+    ;jmp tx_write_pin
     wait 1 irq 0
     // CPU then starts state machine execution
 
@@ -123,11 +126,12 @@ public tx_conflict:
 .program sm_tx_ack
     // CPU first disables state machine execution
     // CPU clears irq 2 and irq 3
-    // CPU changes instruction at tx_loop from "nop" to:
+    // CPU changes instruction at tx_loop from "out x, 1" to:
     irq wait 3
     // CPU then loads tx fifo with ack (single off bit)
     set pins, 1
-    ;jmp tx_start
+    out x, 1
+    ;jmp tx_write_pin
     wait 1 irq 2
     // CPU then starts state machine execution
     // CPU then loads match fifo with CRC/position sequence to check

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -79,7 +79,7 @@ rp2040_gpio_peripheral(uint32_t gpio, int func, int pull_up)
 #define can2040_offset_match_end 25u
 #define can2040_offset_tx_got_recessive 25u
 #define can2040_offset_tx_start 26u
-#define can2040_offset_tx_conflict 31u
+#define can2040_offset_tx_conflict 30u
 
 static const uint16_t can2040_program_instructions[] = {
     0x0085, //  0: jmp    y--, 5
@@ -109,11 +109,10 @@ static const uint16_t can2040_program_instructions[] = {
     0xa0e2, // 24: mov    osr, y
     0xa242, // 25: nop                           [2]
     0x6021, // 26: out    x, 1
-    0xa001, // 27: mov    pins, x
-    0x20c4, // 28: wait   1 irq, 4
-    0x00d9, // 29: jmp    pin, 25
-    0x023a, // 30: jmp    !x, 26                 [2]
-    0x001f, // 31: jmp    31
+    0xb401, // 27: mov    pins, x                [20]
+    0x06d9, // 28: jmp    pin, 25                [6]
+    0x023a, // 29: jmp    !x, 26                 [2]
+    0x001e, // 30: jmp    30
 };
 
 // Local names for PIO state machine IRQs

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -247,6 +247,7 @@ static void
 pio_tx_reset(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
+    pio_hw->ctrl = 0x07 << PIO_CTRL_SM_ENABLE_LSB;
     pio_hw->ctrl = ((0x07 << PIO_CTRL_SM_ENABLE_LSB)
                     | (0x08 << PIO_CTRL_SM_RESTART_LSB));
     pio_hw->irq = (SI_MATCHED | SI_ACKDONE) >> 8; // clear PIO irq flags
@@ -255,9 +256,6 @@ pio_tx_reset(struct can2040 *cd)
     sm->shiftctrl = 0;
     sm->shiftctrl = (PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS
                      | PIO_SM0_SHIFTCTRL_AUTOPULL_BITS);
-    // Must reset again after clearing fifo
-    pio_hw->ctrl = ((0x07 << PIO_CTRL_SM_ENABLE_LSB)
-                    | (0x08 << PIO_CTRL_SM_RESTART_LSB));
 }
 
 // Queue a message for transmission on PIO "tx" state machine

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -76,15 +76,15 @@ rp2040_gpio_peripheral(uint32_t gpio, int func, int pull_up)
 #define can2040_offset_shared_rx_read 13u
 #define can2040_offset_shared_rx_end 15u
 #define can2040_offset_match_load_next 18u
+#define can2040_offset_tx_conflict 24u
 #define can2040_offset_match_end 25u
 #define can2040_offset_tx_got_recessive 25u
-#define can2040_offset_tx_start 26u
-#define can2040_offset_tx_conflict 30u
+#define can2040_offset_tx_write_pin 27u
 
 static const uint16_t can2040_program_instructions[] = {
     0x0085, //  0: jmp    y--, 5
     0x0048, //  1: jmp    x--, 8
-    0xe129, //  2: set    x, 9                   [1]
+    0xe029, //  2: set    x, 9
     0x00cc, //  3: jmp    pin, 12
     0xc000, //  4: irq    nowait 0
     0x00c0, //  5: jmp    pin, 0
@@ -98,7 +98,7 @@ static const uint16_t can2040_program_instructions[] = {
     0x20c4, // 13: wait   1 irq, 4
     0x4001, // 14: in     pins, 1
     0xa046, // 15: mov    y, isr
-    0x00b2, // 16: jmp    x != y, 18
+    0x01b2, // 16: jmp    x != y, 18             [1]
     0xc002, // 17: irq    nowait 2
     0x40eb, // 18: in     osr, 11
     0x4054, // 19: in     y, 20
@@ -107,12 +107,13 @@ static const uint16_t can2040_program_instructions[] = {
     0xa027, // 22: mov    x, osr
     0x0098, // 23: jmp    y--, 24
     0xa0e2, // 24: mov    osr, y
-    0xa242, // 25: nop                           [2]
-    0x6021, // 26: out    x, 1
-    0xb401, // 27: mov    pins, x                [20]
-    0x06d9, // 28: jmp    pin, 25                [6]
-    0x023a, // 29: jmp    !x, 26                 [2]
-    0x001e, // 30: jmp    30
+    0x6021, // 25: out    x, 1
+    0x00df, // 26: jmp    pin, 31
+    0xb801, // 27: mov    pins, x                [24]
+    0x02d9, // 28: jmp    pin, 25                [2]
+    0x0058, // 29: jmp    x--, 24
+    0x6021, // 30: out    x, 1
+    0x011b, // 31: jmp    27                     [1]
 };
 
 // Local names for PIO state machine IRQs
@@ -137,7 +138,7 @@ pio_sync_setup(struct can2040 *cd)
         | cd->gpio_rx << PIO_SM0_PINCTRL_SET_BASE_LSB);
     sm->instr = 0xe080; // set pindirs, 0
     sm->pinctrl = 0;
-    pio_hw->txf[0] = 8 + 6 * PIO_CLOCK_PER_BIT / 2;
+    pio_hw->txf[0] = 9 + 6 * PIO_CLOCK_PER_BIT / 2;
     sm->instr = 0x80a0; // pull block
     sm->instr = can2040_offset_sync_entry; // jmp sync_entry
 }
@@ -182,7 +183,10 @@ pio_tx_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
     struct pio_sm_hw *sm = &pio_hw->sm[3];
-    sm->execctrl = cd->gpio_rx << PIO_SM0_EXECCTRL_JMP_PIN_LSB;
+    sm->execctrl = (
+        cd->gpio_rx << PIO_SM0_EXECCTRL_JMP_PIN_LSB
+        | can2040_offset_tx_conflict << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
+        | can2040_offset_tx_conflict << PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB);
     sm->shiftctrl = (PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS
                      | PIO_SM0_SHIFTCTRL_AUTOPULL_BITS);
     sm->pinctrl = (1 << PIO_SM0_PINCTRL_SET_COUNT_LSB
@@ -263,13 +267,14 @@ pio_tx_send(struct can2040 *cd, uint32_t *data, uint32_t count)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
     pio_tx_reset(cd);
-    pio_hw->instr_mem[can2040_offset_tx_got_recessive] = 0xa242; // nop [2]
+    pio_hw->instr_mem[can2040_offset_tx_got_recessive] = 0x6021; // out x, 1
     uint32_t i;
     for (i=0; i<count; i++)
         pio_hw->txf[3] = data[i];
     struct pio_sm_hw *sm = &pio_hw->sm[3];
     sm->instr = 0xe001; // set pins, 1
-    sm->instr = can2040_offset_tx_start; // jmp tx_start
+    sm->instr = 0x6021; // out x, 1
+    sm->instr = can2040_offset_tx_write_pin; // jmp tx_write_pin
     sm->instr = 0x20c0; // wait 1 irq, 0
     pio_hw->ctrl = 0x0f << PIO_CTRL_SM_ENABLE_LSB;
 }
@@ -284,7 +289,8 @@ pio_tx_inject_ack(struct can2040 *cd, uint32_t match_key)
     pio_hw->txf[3] = 0x7fffffff;
     struct pio_sm_hw *sm = &pio_hw->sm[3];
     sm->instr = 0xe001; // set pins, 1
-    sm->instr = can2040_offset_tx_start; // jmp tx_start
+    sm->instr = 0x6021; // out x, 1
+    sm->instr = can2040_offset_tx_write_pin; // jmp tx_write_pin
     sm->instr = 0x20c2; // wait 1 irq, 2
     pio_hw->ctrl = 0x0f << PIO_CTRL_SM_ENABLE_LSB;
 

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -84,13 +84,13 @@ rp2040_gpio_peripheral(uint32_t gpio, int func, int pull_up)
 static const uint16_t can2040_program_instructions[] = {
     0x0085, //  0: jmp    y--, 5
     0x0048, //  1: jmp    x--, 8
-    0xe12a, //  2: set    x, 10                  [1]
+    0xe129, //  2: set    x, 9                   [1]
     0x00cc, //  3: jmp    pin, 12
     0xc000, //  4: irq    nowait 0
     0x00c0, //  5: jmp    pin, 0
     0xc040, //  6: irq    clear 0
-    0xe229, //  7: set    x, 9                   [2]
-    0xf242, //  8: set    y, 2                   [18]
+    0xe429, //  7: set    x, 9                   [4]
+    0xf043, //  8: set    y, 3                   [16]
     0xc104, //  9: irq    nowait 4               [1]
     0x03c5, // 10: jmp    pin, 5                 [3]
     0x0307, // 11: jmp    7                      [3]
@@ -137,7 +137,7 @@ pio_sync_setup(struct can2040 *cd)
         | cd->gpio_rx << PIO_SM0_PINCTRL_SET_BASE_LSB);
     sm->instr = 0xe080; // set pindirs, 0
     sm->pinctrl = 0;
-    pio_hw->txf[0] = PIO_CLOCK_PER_BIT / 2 * 7 - 5 - 1;
+    pio_hw->txf[0] = 8 + 6 * PIO_CLOCK_PER_BIT / 2;
     sm->instr = 0x80a0; // pull block
     sm->instr = can2040_offset_sync_entry; // jmp sync_entry
 }


### PR DESCRIPTION
This PR changes the code so that CanTx bit transmit timing is no longer dependent on the received CanRx bit timing.

It is normal for there to be 100+ nanoseconds of delay between a change to the CanTx line and its reception on the CanRx line.  At higher canbus frequencies this delay could result in significant skew to the tx bit timing.

This problem wasn't always seen because the CanRx time resynchronizing code would only stretch the bit timing if it detected a passive to dominant edge 1/16th of the bit time delayed - a delay larger than that would be ignored.

Looking at the canbus spec, it seems to indicate that tx bit timing should be dependent on CanRx bit resynchronization, but only if it detects a faster transmitter.  (That is, it should only resynchronize to faster transmitters, not slower transmitters.)  It's not immediately clear that this more advanced logic could be implemented in the PIO.  This PR just entirely disables bit timing on transmits (that is, it wont resynchronize to faster transmitters nor slower transmitters).

In addition to the bit timing change, this PR also adds a check for a received message with the same id as a requested transmit, but with different payload.  (An improved error check that may help catch obscure corner cases with different tx and rx sampling points.)

The PR also increases the slow transmitter detection range (it can resynchronize to an edge that is up to 1/8th of a bit time delayed).

This PR is currently intended for discussion and testing.

-Kevin