### PR TITLE
Fix check for "tx_conflict"

### DIFF
--- a/pio/can2040.pio
+++ b/pio/can2040.pio
@@ -76,7 +76,7 @@ public tx_start:
     jmp pin tx_got_recessive    ; cp=26
     jmp !x tx_start        [2]  ; cp=27
 public tx_conflict:
-    irq wait 7
+    jmp tx_conflict
 
 
 //

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -113,7 +113,7 @@ static const uint16_t can2040_program_instructions[] = {
     0x20c4, // 28: wait   1 irq, 4
     0x00d9, // 29: jmp    pin, 25
     0x023a, // 30: jmp    !x, 26                 [2]
-    0xc027, // 31: irq    wait 7
+    0x001f, // 31: jmp    31
 };
 
 // Local names for PIO state machine IRQs


### PR DESCRIPTION
The code was not properly detecting a "tx conflict" condition on transmits.  As a result, the code may not reattempt a failed transmission until some other node on the canbus initiates a transmit. If no other node attempts a transmit for an extended period of time it could result in can2040 "locking up" for that extended duration.

The error was due to the PIO hardware reporting of the active instruction address.  On an "irq wait" command it was reporting the address of the next instruction.

~~Update the PIO tx state machine to use the PIO "address wrap" system so that the address is reported as the "tx_conflict" address before and after the "irq wait" instruction.~~  Update the PIO tx state machine to loop on the "tx_conflict" address.  This allows the host software to correctly identify if the tx state machine has observed a transmit bit conflict.

-Kevin

EDIT: Minor change to the implementation of the fix.