### PR TITLE
Add support for can2040_stop() to stop processing of CAN bus messages

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -226,6 +226,26 @@ supplied `can2040_rx_cb` callback function.
 It is valid to invoke `can2040_check_transmit()` on one ARM core while
 the other ARM core may be running `can2040_pio_irq_handler()`.
 
+## can2040_stop
+
+`void can2040_stop(struct can2040 *cd)`
+
+This function disables processing of can2040 CAN bus messages.  Upon
+completion of this function the user supplied `can2040_rx_cb()`
+callback function will no longer be invoked.
+
+If this function is called while a message is queued for transmit then
+it is possible that the message may be successfully transmitted
+without it being removed from the local transmit queue and without a
+`CAN2040_NOTIFY_TX` event sent to the user supplied `can2040_rx_cb()`
+callback function,
+
+The can2040 CAN bus processing may be restarted by calling
+`can2040_start()`.
+
+To clear the transmit queue before restarting, call `can2040_setup()`,
+`can2040_callback_config()`, and then `can2040_start()`.
+
 # Not reentrant safe
 
 Unless explicitly stated otherwise, the can2040 code is not reentrant

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -318,6 +318,14 @@ pio_irq_set(struct can2040 *cd, uint32_t sm_irqs)
     pio_hw->inte0 = sm_irqs | SI_RX_DATA;
 }
 
+// Completely disable host irqs
+static void
+pio_irq_disable(struct can2040 *cd)
+{
+    pio_hw_t *pio_hw = cd->pio_hw;
+    pio_hw->inte0 = 0;
+}
+
 // Return current host irq mask
 static uint32_t
 pio_irq_get(struct can2040 *cd)
@@ -896,6 +904,13 @@ enum {
     MS_CRC, MS_ACK, MS_EOF0, MS_EOF1, MS_DISCARD
 };
 
+// Reset any bits in the incoming parsing state
+static void
+data_state_clear_bits(struct can2040 *cd)
+{
+    cd->raw_bit_count = cd->unstuf.stuffed_bits = cd->unstuf.count_stuff = 0;
+}
+
 // Transition to the next parsing state
 static void
 data_state_go_next(struct can2040 *cd, uint32_t state, uint32_t num_bits)
@@ -912,7 +927,7 @@ data_state_go_discard(struct can2040 *cd)
 
     if (pio_rx_check_stall(cd)) {
         // CPU couldn't keep up for some read data - must reset pio state
-        cd->raw_bit_count = cd->unstuf.count_stuff = 0;
+        data_state_clear_bits(cd);
         pio_sm_setup(cd);
         report_callback_error(cd, 0);
     }
@@ -941,8 +956,7 @@ data_state_line_passive(struct can2040 *cd)
     uint32_t dom_bits = ~stuffed_bits;
     if (!dom_bits) {
         // Counter overflow in "sync" state machine - reset it
-        cd->unstuf.stuffed_bits = 0;
-        cd->raw_bit_count = cd->unstuf.count_stuff = 0;
+        data_state_clear_bits(cd);
         pio_sm_setup(cd);
         data_state_go_discard(cd);
         return;
@@ -1310,13 +1324,15 @@ can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate
 {
     cd->gpio_rx = gpio_rx;
     cd->gpio_tx = gpio_tx;
+    data_state_clear_bits(cd);
     pio_setup(cd, sys_clock, bitrate);
     data_state_go_discard(cd);
 }
 
-// API function to stop and uninitialize can2040 code
+// API function to stop can2040 code
 void
-can2040_shutdown(struct can2040 *cd)
+can2040_stop(struct can2040 *cd)
 {
-    // XXX
+    pio_irq_disable(cd);
+    pio_sm_setup(cd);
 }

--- a/src/can2040.h
+++ b/src/can2040.h
@@ -30,7 +30,7 @@ void can2040_setup(struct can2040 *cd, uint32_t pio_num);
 void can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb);
 void can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate
                    , uint32_t gpio_rx, uint32_t gpio_tx);
-void can2040_shutdown(struct can2040 *cd);
+void can2040_stop(struct can2040 *cd);
 void can2040_pio_irq_handler(struct can2040 *cd);
 int can2040_check_transmit(struct can2040 *cd);
 int can2040_transmit(struct can2040 *cd, struct can2040_msg *msg);


### PR DESCRIPTION
This adds an API function to stop CAN bus processing.  The new `can2040_stop()` effectively does the inverse of `can2040_start()`.  After stopping, one may call `can2040_start()` again, or fully clear the transmit queue and restart by redoing the init starting from `can2040_setup()`.  See the updated API documentation on this branch for further details.

I don't have a good way to test this code right now.  I'm posting it in case others are looking for this functionality.

-Kevin