### PR TITLE
Added a max retry counter.

### DIFF
--- a/src/can2040.c
+++ b/src/can2040.c
@@ -756,6 +756,7 @@ report_handle_eof(struct can2040 *cd)
         // Successfully processed a new message - report to calling code
         pio_sync_normal_start_signal(cd);
         if (cd->report_state == RS_NEED_TX_EOF)
+            writel(&cd->retry_count, 0);
             report_callback_tx_msg(cd);
         else
             report_callback_rx_msg(cd);

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -755,11 +755,12 @@ report_handle_eof(struct can2040 *cd)
     if (cd->report_state & RS_NEED_EOF_FLAG) { // RS_NEED_xX_EOF
         // Successfully processed a new message - report to calling code
         pio_sync_normal_start_signal(cd);
-        if (cd->report_state == RS_NEED_TX_EOF)
+        if (cd->report_state == RS_NEED_TX_EOF) {
             writel(&cd->retry_count, 0);
             report_callback_tx_msg(cd);
-        else
+        } else {
             report_callback_rx_msg(cd);
+        }
     } else if (cd->report_state & RS_NEED_TX_ACK) {
         uint32_t retry_count = cd->retry_count;
         writel(&cd->retry_count, retry_count + 1);

--- a/src/can2040.h
+++ b/src/can2040.h
@@ -29,7 +29,7 @@ typedef void (*can2040_rx_cb)(struct can2040 *cd, uint32_t notify
 void can2040_setup(struct can2040 *cd, uint32_t pio_num);
 void can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb);
 void can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate
-                   , uint32_t gpio_rx, uint32_t gpio_tx);
+                   , uint32_t gpio_rx, uint32_t gpio_tx, uint32_t max_retries);
 void can2040_stop(struct can2040 *cd);
 void can2040_pio_irq_handler(struct can2040 *cd);
 int can2040_check_transmit(struct can2040 *cd);
@@ -73,6 +73,8 @@ struct can2040 {
     uint32_t tx_state;
     uint32_t tx_pull_pos, tx_push_pos;
     struct can2040_transmit tx_queue[4];
+    uint32_t retry_count;
+    uint32_t retry_max;
 };
 
 #endif // can2040.h


### PR DESCRIPTION
This is used to limit the number of attempts to send a single can msg. It can be used to detect if there are errors on the canbus, such as NACK on every frame. This is implemented by adding an additional parameter to can2040_start which specifies the max number of retries before returning an error and continuing to the next message in the tx queue. An error status is returned to the can2040_cb function. Since this is the first additional error type, it uses 1 anded with CAN2040_NOTIFY_ERROR to signify the difference of error type. This can be documented better on request. In order to disreguard this functionality, -1 can be passed as retry_max to can2040_start.