### PR TITLE
Add mechanism for obtaining low-level can2040 statistics

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -246,6 +246,52 @@ The can2040 CAN bus processing may be restarted by calling
 To clear the transmit queue before restarting, call `can2040_setup()`,
 `can2040_callback_config()`, and then `can2040_start()`.
 
+## can2040_get_statistics
+
+`void can2040_get_statistics(struct can2040 *cd, struct can2040_stats *stats)`
+
+This function may be called to obtain can2040 receive and transmit
+statistics.  This may be useful for insight on how well the CAN bus
+network hardware is performing.
+
+The caller must allocate a `struct can2040_stats` and pass a pointer
+to it in the `stats` parameter.  The `can2040_get_statistics()`
+function will copy its internal can2040 statistics to the provided
+struct.  The caller may then inspect its local copy of `struct
+can2040_stats` after the function completes.
+
+The `can2040.h` header file provides the definition for `struct
+can2040_stats`.  It has the following fields:
+* `rx_total`: The total number of successfully received messages.
+  This is the number of times that `can2040_rx_cb()` is invoked with
+  `CAN2040_NOTIFY_RX`.
+* `tx_total`: The total number of successfully transmitted messages.
+  This is the number of times that `can2040_rx_cb()` is invoked with
+  `CAN2040_NOTIFY_TX`.
+* `tx_attempt`: The total number of transmit attempts.  If this is
+  more than one greater than `tx_total` it indicates some transmits
+  were retried.  A transmit may be retried due to line arbitration (a
+  transmit attempt was interrupted by a higher priority transmission
+  from another node on the CAN bus), due to the lack of an
+  acknowledgment from another node on the CAN bus, or due to some
+  other parse error during a transmit attempt.
+* `parse_error`: The total number of data errors observed during
+  content parsing on the CAN bus.  This may increment due to hardware
+  noise on the CAN bus, due to error frames generated from other nodes
+  on the CAN bus, due to lack of transmit acknowledgments on the CAN
+  bus, or due to some other error in read data.
+
+The above counters are only set to zero during the initial call to
+`can2040_setup()`.  One may call `can2040_get_statistics()`
+periodically and subtract each counter from the value found at the
+previous call to obtain the statistics over that discrete period.
+When subtracting, it is recommended to store the difference in a
+`uint32_t` for improved handling of 32bit counter rollovers.
+
+It is valid to invoke `can2040_get_statistics()` at any time after
+`can2040_setup()` is called (including from another ARM core and
+including from the user supplied `can2040_rx_cb` callback function).
+
 # Not reentrant safe
 
 Unless explicitly stated otherwise, the can2040 code is not reentrant

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -926,8 +926,6 @@ data_state_go_next(struct can2040 *cd, uint32_t state, uint32_t num_bits)
 static void
 data_state_go_discard(struct can2040 *cd)
 {
-    report_note_discarding(cd);
-
     if (pio_rx_check_stall(cd)) {
         // CPU couldn't keep up for some read data - must reset pio state
         data_state_clear_bits(cd);
@@ -936,6 +934,9 @@ data_state_go_discard(struct can2040 *cd)
     }
 
     data_state_go_next(cd, MS_DISCARD, 32);
+
+    // Clear report state and update hw irqs after transition to MS_DISCARD
+    report_note_discarding(cd);
 }
 
 // Note a data parse error and transition to discard state

--- a/src/can2040.h
+++ b/src/can2040.h
@@ -26,11 +26,18 @@ struct can2040;
 typedef void (*can2040_rx_cb)(struct can2040 *cd, uint32_t notify
                               , struct can2040_msg *msg);
 
+struct can2040_stats {
+    uint32_t rx_total, tx_total;
+    uint32_t tx_attempt;
+    uint32_t parse_error;
+};
+
 void can2040_setup(struct can2040 *cd, uint32_t pio_num);
 void can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb);
 void can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate
                    , uint32_t gpio_rx, uint32_t gpio_tx);
 void can2040_stop(struct can2040 *cd);
+void can2040_get_statistics(struct can2040 *cd, struct can2040_stats *stats);
 void can2040_pio_irq_handler(struct can2040 *cd);
 int can2040_check_transmit(struct can2040 *cd);
 int can2040_transmit(struct can2040 *cd, struct can2040_msg *msg);
@@ -56,6 +63,7 @@ struct can2040 {
     void *pio_hw;
     uint32_t gpio_rx, gpio_tx;
     can2040_rx_cb rx_cb;
+    struct can2040_stats stats;
 
     // Bit unstuffing
     struct can2040_bitunstuffer unstuf;


### PR DESCRIPTION
This PR adds a new `can2040_get_statistics()` API interface.  It is intended to allow users of can2040 to get insight into how well the CAN bus hardware is performing.  For example, to determine if there are many errors and/or retransmit attempts.

This PR is just for discussion.  I have not adequately tested this PR at this time.

@linted - FYI, as mentioned in PR #44 

-Kevin