### PR TITLE
PicoSDK v2.0.0 compatibility

### DIFF
--- a/src/can2040.c
+++ b/src/can2040.c
@@ -128,7 +128,7 @@ static void
 pio_sync_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[0];
+    pio_sm_hw_t *sm = &pio_hw->sm[0];
     sm->execctrl = (
         cd->gpio_rx << PIO_SM0_EXECCTRL_JMP_PIN_LSB
         | (can2040_offset_sync_end - 1) << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
@@ -148,7 +148,7 @@ static void
 pio_rx_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[1];
+    pio_sm_hw_t *sm = &pio_hw->sm[1];
     sm->execctrl = (
         (can2040_offset_shared_rx_end - 1) << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
         | can2040_offset_shared_rx_read << PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB);
@@ -165,7 +165,7 @@ static void
 pio_match_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[2];
+    pio_sm_hw_t *sm = &pio_hw->sm[2];
     sm->execctrl = (
         (can2040_offset_match_end - 1) << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
         | can2040_offset_shared_rx_read << PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB);
@@ -182,7 +182,7 @@ static void
 pio_tx_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->execctrl = (
         cd->gpio_rx << PIO_SM0_EXECCTRL_JMP_PIN_LSB
         | can2040_offset_tx_conflict << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
@@ -255,7 +255,7 @@ pio_tx_reset(struct can2040 *cd)
                     | (0x08 << PIO_CTRL_SM_RESTART_LSB));
     pio_hw->irq = (SI_MATCHED | SI_ACKDONE) >> 8; // clear PIO irq flags
     // Clear tx fifo
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->shiftctrl = 0;
     sm->shiftctrl = (PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS
                      | PIO_SM0_SHIFTCTRL_AUTOPULL_BITS);
@@ -271,7 +271,7 @@ pio_tx_send(struct can2040 *cd, uint32_t *data, uint32_t count)
     uint32_t i;
     for (i=0; i<count; i++)
         pio_hw->txf[3] = data[i];
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->instr = 0xe001; // set pins, 1
     sm->instr = 0x6021; // out x, 1
     sm->instr = can2040_offset_tx_write_pin; // jmp tx_write_pin
@@ -287,7 +287,7 @@ pio_tx_inject_ack(struct can2040 *cd, uint32_t match_key)
     pio_tx_reset(cd);
     pio_hw->instr_mem[can2040_offset_tx_got_recessive] = 0xc023; // irq wait 3
     pio_hw->txf[3] = 0x7fffffff;
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->instr = 0xe001; // set pins, 1
     sm->instr = 0x6021; // out x, 1
     sm->instr = can2040_offset_tx_write_pin; // jmp tx_write_pin


### PR DESCRIPTION
In Pico SDK version 1.5.1, the use of `struct pio_sm_hw *` was still tolerated because the [name of the struct was defined](https://github.com/raspberrypi/pico-sdk/blob/1.5.1/src/rp2040/hardware_structs/include/hardware/structs/pio.h#L23).

However in Pico SDK version 2.0.0, the [struct name was removed](https://github.com/raspberrypi/pico-sdk/blob/2.0.0/src/rp2040/hardware_structs/include/hardware/structs/pio.h#L26), lefting only the `typedef` name `pio_sm_hw_t` and generating the following error at compilation:

```
build/_deps/can2040_repo-src/src/can2040.c:131:28: warning: initialization of 'struct pio_sm_hw *' from incompatible pointer type 'pio_sm_hw_t *' [-Wincompatible-pointer-types]
  131 |     struct pio_sm_hw *sm = &pio_hw->sm[0];
      |                            ^
build/_deps/can2040_repo-src/src/can2040.c:132:7: error: invalid use of undefined type 'struct pio_sm_hw'
  132 |     sm->execctrl = (
      |       ^~
build/_deps/can2040_repo-src/src/can2040.c:136:7: error: invalid use of undefined type 'struct pio_sm_hw'
  136 |     sm->pinctrl = (
      |       ^~
build/_deps/can2040_repo-src/src/can2040.c:139:7: error: invalid use of undefined type 'struct pio_sm_hw'
  139 |     sm->instr = 0xe080; // set pindirs, 0
      |       ^~
build/_deps/can2040_repo-src/src/can2040.c:140:7: error: invalid use of undefined type 'struct pio_sm_hw'
  140 |     sm->pinctrl = 0;
      |       ^~
build/_deps/can2040_repo-src/src/can2040.c:142:7: error: invalid use of undefined type 'struct pio_sm_hw'
  142 |     sm->instr = 0x80a0; // pull block
      |       ^~
build/_deps/can2040_repo-src/src/can2040.c:143:7: error: invalid use of undefined type 'struct pio_sm_hw'
  143 |     sm->instr = can2040_offset_sync_entry; // jmp sync_entry
      |       ^~
```

This pull requests replaces every use of `struct pio_sm_hw` by `pio_sm_hw_t` in order to pass Pico SDK 2.0.0 compilation