### PR TITLE
Support v2.0.0 of the pico-sdk

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,9 +11,10 @@ compiler. The can2040 implementation is contained in the
 files.  The code is intended to be compiled at `-O2` (or higher)
 optimization.
 
-The code depends on a few files from the [rp2040
-sdk](https://github.com/raspberrypi/pico-sdk.git) that must be in the
-include path when compiling can2040.  For example:
+The code depends on a few files from the
+[rp2040 sdk](https://github.com/raspberrypi/pico-sdk.git) (version
+1.3.0 or later) that must be in the include path when compiling
+can2040.  For example:
 `arm-none-eabi-gcc -O2 -I/path/to/sdk/src/rp2040/ -I/path/to/sdk/src/rp2_common/cmsis/stub/CMSIS/Device/RaspberryPi/RP2040/Include/ ...`
 
 # Startup

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -128,7 +128,7 @@ static void
 pio_sync_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[0];
+    pio_sm_hw_t *sm = &pio_hw->sm[0];
     sm->execctrl = (
         cd->gpio_rx << PIO_SM0_EXECCTRL_JMP_PIN_LSB
         | (can2040_offset_sync_end - 1) << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
@@ -148,7 +148,7 @@ static void
 pio_rx_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[1];
+    pio_sm_hw_t *sm = &pio_hw->sm[1];
     sm->execctrl = (
         (can2040_offset_shared_rx_end - 1) << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
         | can2040_offset_shared_rx_read << PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB);
@@ -165,7 +165,7 @@ static void
 pio_match_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[2];
+    pio_sm_hw_t *sm = &pio_hw->sm[2];
     sm->execctrl = (
         (can2040_offset_match_end - 1) << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
         | can2040_offset_shared_rx_read << PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB);
@@ -182,7 +182,7 @@ static void
 pio_tx_setup(struct can2040 *cd)
 {
     pio_hw_t *pio_hw = cd->pio_hw;
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->execctrl = (
         cd->gpio_rx << PIO_SM0_EXECCTRL_JMP_PIN_LSB
         | can2040_offset_tx_conflict << PIO_SM0_EXECCTRL_WRAP_TOP_LSB
@@ -255,7 +255,7 @@ pio_tx_reset(struct can2040 *cd)
                     | (0x08 << PIO_CTRL_SM_RESTART_LSB));
     pio_hw->irq = (SI_MATCHED | SI_ACKDONE) >> 8; // clear PIO irq flags
     // Clear tx fifo
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->shiftctrl = 0;
     sm->shiftctrl = (PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS
                      | PIO_SM0_SHIFTCTRL_AUTOPULL_BITS);
@@ -271,7 +271,7 @@ pio_tx_send(struct can2040 *cd, uint32_t *data, uint32_t count)
     uint32_t i;
     for (i=0; i<count; i++)
         pio_hw->txf[3] = data[i];
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->instr = 0xe001; // set pins, 1
     sm->instr = 0x6021; // out x, 1
     sm->instr = can2040_offset_tx_write_pin; // jmp tx_write_pin
@@ -287,7 +287,7 @@ pio_tx_inject_ack(struct can2040 *cd, uint32_t match_key)
     pio_tx_reset(cd);
     pio_hw->instr_mem[can2040_offset_tx_got_recessive] = 0xc023; // irq wait 3
     pio_hw->txf[3] = 0x7fffffff;
-    struct pio_sm_hw *sm = &pio_hw->sm[3];
+    pio_sm_hw_t *sm = &pio_hw->sm[3];
     sm->instr = 0xe001; // set pins, 1
     sm->instr = 0x6021; // out x, 1
     sm->instr = can2040_offset_tx_write_pin; // jmp tx_write_pin

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -6,8 +6,8 @@
 
 #include <stdint.h> // uint32_t
 #include <string.h> // memset
-#include "RP2040.h" // hw_set_bits
 #include "can2040.h" // can2040_setup
+#include "cmsis_gcc.h" // __DMB
 #include "hardware/regs/dreq.h" // DREQ_PIO0_RX1
 #include "hardware/structs/dma.h" // dma_hw
 #include "hardware/structs/iobank0.h" // iobank0_hw


### PR DESCRIPTION
Replace 'struct pio_sm_hw' with 'pio_sm_hw_t' so that the code can be compiled with the v2.0.0 release of the pico-sdk.  The 'pio_sm_hw_t' was introduced in sdk version 1.3.0, so that is now the minimum required version of the sdk.

As referenced in #54, #55, and #56.

-Kevin