### PR TITLE
Improved rp2350 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 The can2040 project is a software CAN bus implementation for Raspberry
-Pi [rp2040](https://www.raspberrypi.com/products/rp2040/)
-micro-controllers.  It enables an rp2040 chip to implement
+Pi [rp2040](https://www.raspberrypi.com/products/rp2040/) and
+[rp2350](https://www.raspberrypi.com/products/rp2350/)
+micro-controllers.  It enables these chips to implement
 [CAN bus](https://en.wikipedia.org/wiki/CAN_bus) using a standard CAN
 transceiver chip.  The code supports reading and writing CAN 2.0B data
 frames at rates up to 1Mbit per second.

--- a/docs/API.md
+++ b/docs/API.md
@@ -163,13 +163,19 @@ The `sys_clock` parameter specifies the system clock rate (for example
 The `bitrate` parameter specifies the CAN bus speed (for example
 `500000` for a 500Kbit/s CAN bus).
 
-The `gpio_rx` parameter specifies the rp2040/rp2350 gpio number that
-is routed to the "CAN RX" pin of the CAN bus transceiver.  It should
-be between 0 and 29 (for GPIO0 to GPIO29).
+The `gpio_rx` parameter specifies the gpio number that is routed to
+the "CAN RX" pin of the CAN bus transceiver.  On rp2040 it should be
+between 0 and 29 (for GPIO0 to GPIO29).  On the rp2350 chips it may be
+between 0 and 31 (for GPIO0 to GPIO31), or alternatively between 16
+and 47 (for GPIO16 to GPIO47) if both `gpio_rx` and `gpio_tx` are
+between 16 and 47.
 
-The `gpio_tx` parameter specifies the rp2040/rp2340 gpio number that
-is routed to the "CAN TX" pin of the CAN bus transceiver.  It should
-be between 0 and 29 (for GPIO0 to GPIO29).
+The `gpio_tx` parameter specifies the gpio number that is routed to
+the "CAN TX" pin of the CAN bus transceiver.  On rp2040 chips it
+should be between 0 and 29 (for GPIO0 to GPIO29).  On the rp2350 chips
+it may be between 0 and 31 (for GPIO0 to GPIO31), or alternatively
+between 16 and 47 (for GPIO16 to GPIO47) if both `gpio_rx` and
+`gpio_tx` are between 16 and 47.
 
 After calling this function, activity on the CAN bus may result in the
 user specified `can2040_rx_cb` callback being invoked.

--- a/docs/Code_Overview.md
+++ b/docs/Code_Overview.md
@@ -4,8 +4,8 @@ information on the can2040 code organization and objectives.
 
 # PIO state machines
 
-The can2040 code uses the rp2040 PIO (Programmable Input Output)
-hardware feature.  See the [rp2040
+The can2040 code uses the rp2040/rp2350 PIO (Programmable Input
+Output) hardware feature.  See the [rp2040
 datasheet](https://www.raspberrypi.com/documentation/microcontrollers/rp2040.html)
 for information on the hardware.
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -19,7 +19,8 @@ bus implementation.
 
 * Works with standard CAN bus transceivers.  On the rp2040, any two
   gpio pins may be used for the "can rx" and "can tx" wires.  On the
-  rp2350, any two gpio pins from GPIO0 to GPIO31 may be used.
+  rp2350, any two gpio pins from GPIO0 to GPIO31 or any two pins from
+  GPIO16 to GPIO47 may be used.
 
 # Protocol details
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -12,12 +12,14 @@ bus implementation.
 * Interoperates with other CAN bus implementations.  A bus may consist
   of one or more can2040 nodes along with non-can2040 nodes.
 
-* The implementation uses one of the two rp2040 PIO hardware blocks.
-  It is possible for a single rp2040 chip to have two separate CAN bus
-  interfaces by using both PIO blocks.
+* The implementation uses one rp2040/rp2350 PIO hardware block.  A
+  single rp2040 chip may have two separate CAN bus interfaces by using
+  both of its PIO blocks.  A single rp2350 chip may have three
+  separate CAN bus interfaces.
 
-* Works with standard CAN bus transceivers.  Any two rp2040 gpio pins
-  may be used for the "can rx" and "can tx" wires.
+* Works with standard CAN bus transceivers.  On the rp2040, any two
+  gpio pins may be used for the "can rx" and "can tx" wires.  On the
+  rp2350, any two gpio pins from GPIO0 to GPIO31 may be used.
 
 # Protocol details
 
@@ -68,8 +70,8 @@ There are some known limitations with CAN bus error handling:
 # Software utilization
 
 The can2040 system is a software CAN bus implementation.  It utilizes
-the rp2040 PIO device as well as processing time on one of the rp2040
-ARM cores.
+the rp2040/rp2350 PIO device as well as processing time on one of the
+rp2040/rp2350 ARM cores.
 
 One may dedicate an ARM core to can2040.  It is also possible for
 can2040 to share an ARM core with application code.  This section is
@@ -80,11 +82,12 @@ software overhead of can2040 when sharing an ARM core.
   traffic, even if that bus traffic is not intended for the node. It
   is expected that a fully saturated CAN bus at the fastest supported
   rate of 1Mbit/s may use up to ~25% of one of the two rp2040 ARM
-  cores (when the ARM core is running at 125Mhz).  A slower CAN bus
-  speed would have a lower worst case processing time (for example, a
-  bus speed of 500kbit/s is expected to have half the worst case
-  processing time of a 1Mbit/s bus).  A CAN bus that is idle does not
-  consume any ARM core processing time.
+  cores (when the ARM core is running at 125Mhz).  The same rate on an
+  rp2350 is expected to use up to ~15% of one ARM core (when running
+  at 150Mhz).  A slower CAN bus speed would have a lower worst case
+  processing time (for example, a bus speed of 500kbit/s is expected
+  to have half the worst case processing time of a 1Mbit/s bus).  A
+  CAN bus that is idle does not consume any ARM core processing time.
 
 * The can2040 code requires low ARM core "irq latency" for proper
   functionality.  If an ARM core is shared with both application code
@@ -124,6 +127,6 @@ software overhead of can2040 when sharing an ARM core.
   The can2040 irq handler itself may introduce some irq latency (to
   itself and other irq handlers of equal or lower priority).  With an
   ARM core running at 125Mhz, it is expected that each can2040 irq
-  will typically take between 1 to 3 microseconds.  (An rp2040
+  will typically take between 1 to 3 microseconds.  (An rp2040/rp2350
   instruction flash cache miss and/or higher priority irqs may
   increase this time.)

--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -5,12 +5,12 @@ facilitate development and may be useful as coding examples.
 # Klipper
 
 The [Klipper](https://www.klipper3d.org/) code utilizes can2040 for
-micro-controller CAN bus communication on rp2040 chips.
+micro-controller CAN bus communication on rp2040/rp2350 chips.
 
 Klipper can also be compiled in a [USB to CAN bus bridge
 mode](https://www.klipper3d.org/CANBUS.html#usb-to-can-bus-bridge-mode)
-so that an rp2040 device appears as a standard Linux USB to CAN bus
-adapter (using the "gs_usb" Linux driver).  Compiling the Klipper
+so that an rp2040/rp2350 device appears as a standard Linux USB to CAN
+bus adapter (using the "gs_usb" Linux driver).  Compiling the Klipper
 micro-controller code in this mode may be useful for CAN bus
 diagnostics even when not using Klipper.  See the [Klipper
 installation](https://www.klipper3d.org/Installation.html)
@@ -22,16 +22,16 @@ Raspberry Pi computer the installation involves:
    (`sudo apt-get update && sudo apt-get install build-essential libncurses-dev libusb-dev libnewlib-arm-none-eabi gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0 pkg-config`).
 3. Configure the micro-controller software (`make menuconfig`).
    Select "Enable extra low-level configuration options", select
-   "Raspberry Pi RP2040" as the micro-controller, select "No
+   "Raspberry Pi RP2040/RP235x" as the micro-controller, select "No
    bootloader", select "USB to CAN bus bridge", set the appropriate
    gpio pins for CAN RX and CAN TX, and set the desired CAN bus
    frequency.
 4. Build the micro-controller software (`make`).
-5. Place the rp2040 micro-controller in bootloader mode and flash the
-   software (`make flash FLASH_DEVICE=2e8a:0003`).
+5. Place the rp2040/rp2350 micro-controller in bootloader mode and
+   flash the software (`make flash FLASH_DEVICE=2e8a:0003`).
 
-Once the Klipper micro-controller code is running on the rp2040 it is
-possible to use the Linux
+Once the Klipper micro-controller code is running on the rp2040/rp2350
+it is possible to use the Linux
 [can-utils](https://github.com/linux-can/can-utils) tools.  Briefly:
 1. Install the can-utils package
    (`sudo apt-get update && sudo apt-get install can-utils`).
@@ -44,9 +44,9 @@ possible to use the Linux
 4. In another window, send packets on the CAN bus
    (eg, `cansend can0 123#121212121212`).
 
-# CanBoot
+# Katapult
 
-The [CanBoot](https://github.com/Arksine/CanBoot) code implements a
+The [Katapult](https://github.com/Arksine/Katapult) code implements a
 cross-platform bootloader that supports flashing an rp2040
 micro-controller over CAN bus.  It utilizes can2040 on rp2040 chips.
 

--- a/scripts/bitstuf.py
+++ b/scripts/bitstuf.py
@@ -69,6 +69,31 @@ def bitstuf_batch(b, num_bits):
             num_bits -= 1
             try_cnt //= 2
 
+def bitstuf_clz(b, num_bits):
+    global LOOP
+    count = num_bits
+    while 1:
+        LOOP += 1
+        edges = b ^ (b >> 1)
+        e2 = edges | (edges >> 1)
+        e4 = e2 | (e2 >> 2)
+        add_bits = ~e4
+        mask = (1 << num_bits) - 1
+        add_masked_bits = add_bits & mask
+        if not add_masked_bits:
+            # No more stuff bits needed
+            return b, count
+        # Insert a stuff bit
+        stuff_pos = 1 + 31 - clz(add_masked_bits)
+        low_mask = (1 << stuff_pos) - 1
+        low = b & low_mask
+        high = (b & ~(low_mask >> 1)) << 1
+        b = high ^ low ^ (1 << (stuff_pos - 1))
+        count += 1
+        if stuff_pos <= 4:
+            return b, count
+        num_bits = stuff_pos - 4
+
 def bitunstuf(sb, num_bits):
     global UNLOOP
     edges = sb ^ (sb >> 1)


### PR DESCRIPTION
Add support for the pio2_hw block.  Update the documentation to note that the rp2350 chips are supported.

-Kevin