### PR TITLE
Adds basic support for cmake.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.13..3.27)
+
+if(NOT COMMAND pico_sdk_init)
+	# pico_sdk_import.cmake is a single file copied from this SDK note: this
+	# must happen before project()
+	include(pico_sdk_import.cmake)
+endif(NOT COMMAND pico_sdk_init)
+
+project(
+	can2040
+	LANGUAGES C CXX # Note: picotool requires C++
+	VERSION 1.6.0
+)
+
+if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+	set(CAN2040_IS_IMPORTED 1)
+endif(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+
+if(CAN2040_IS_IMPORTED)
+	if(NOT PICO_SDK_PATH)
+		message(
+			FATAL_ERROR "This module must be included after pico_sdk_init()"
+		)
+	endif(NOT PICO_SDK_PATH)
+else(CAN2040_IS_IMPORTED)
+	set(FAMILY
+		rp2040
+		CACHE STRING "family to use"
+	)
+	set(BOARD
+		pico_sdk
+		CACHE STRING "board to use"
+	)
+
+	pico_sdk_init()
+
+	set(CMAKE_C_STANDARD 11)
+	set(CMAKE_C_STANDARD_REQUIRED 1)
+
+	set(CMAKE_CXX_STANDARD 17)
+	set(CMAKE_CXX_STANDARD_REQUIRED 1)
+
+endif(CAN2040_IS_IMPORTED)
+
+add_library(can2040 INTERFACE)
+add_library(can2040::can2040 ALIAS can2040)
+
+target_sources(can2040 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/../src/can2040.c)
+
+target_link_libraries(
+	can2040 INTERFACE pico_stdlib hardware_pio cmsis_core hardware_irq
+)
+
+target_include_directories(can2040 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+
+if(NOT CAN2040_IS_IMPORTED)
+	add_subdirectory(../examples ${CMAKE_CURRENT_BINARY_DIR}/_examples)
+endif(NOT CAN2040_IS_IMPORTED)

--- a/cmake/pico_sdk_import.cmake
+++ b/cmake/pico_sdk_import.cmake
@@ -1,0 +1,119 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK It should
+# be include()ed prior to project()
+
+if(DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+	set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+	message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif()
+
+if(DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+	set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+	message(
+		"Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')"
+	)
+endif()
+
+if(DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT
+												  PICO_SDK_FETCH_FROM_GIT_PATH)
+)
+	set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+	message(
+		"Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')"
+	)
+endif()
+
+if(DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_TAG} AND (NOT PICO_SDK_FETCH_FROM_GIT_TAG
+												)
+)
+	set(PICO_SDK_FETCH_FROM_GIT_TAG $ENV{PICO_SDK_FETCH_FROM_GIT_TAG})
+	message(
+		"Using PICO_SDK_FETCH_FROM_GIT_TAG from environment ('${PICO_SDK_FETCH_FROM_GIT_TAG}')"
+	)
+endif()
+
+if(PICO_SDK_FETCH_FROM_GIT AND NOT PICO_SDK_FETCH_FROM_GIT_TAG)
+	set(PICO_SDK_FETCH_FROM_GIT_TAG "master")
+	message("Using master as default value for PICO_SDK_FETCH_FROM_GIT_TAG")
+endif()
+
+set(PICO_SDK_PATH
+	"${PICO_SDK_PATH}"
+	CACHE PATH "Path to the Raspberry Pi Pico SDK"
+)
+set(PICO_SDK_FETCH_FROM_GIT
+	"${PICO_SDK_FETCH_FROM_GIT}"
+	CACHE BOOL
+		  "Set to ON to fetch copy of SDK from git if not otherwise locatable"
+)
+set(PICO_SDK_FETCH_FROM_GIT_PATH
+	"${PICO_SDK_FETCH_FROM_GIT_PATH}"
+	CACHE FILEPATH "location to download SDK"
+)
+set(PICO_SDK_FETCH_FROM_GIT_TAG
+	"${PICO_SDK_FETCH_FROM_GIT_TAG}"
+	CACHE STRING "release tag for SDK"
+)
+
+if(NOT PICO_SDK_PATH)
+	if(PICO_SDK_FETCH_FROM_GIT)
+		include(FetchContent)
+		set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+		if(PICO_SDK_FETCH_FROM_GIT_PATH)
+			get_filename_component(
+				FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}"
+				REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}"
+			)
+		endif()
+		# GIT_SUBMODULES_RECURSE was added in 3.17
+		if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+			FetchContent_Declare(
+				pico_sdk
+				GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+				GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+				GIT_SUBMODULES_RECURSE FALSE
+			)
+		else()
+			FetchContent_Declare(
+				pico_sdk
+				GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+				GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+			)
+		endif()
+
+		if(NOT pico_sdk)
+			message("Downloading Raspberry Pi Pico SDK")
+			FetchContent_Populate(pico_sdk)
+			set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+		endif()
+		set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+	else()
+		message(
+			FATAL_ERROR
+				"SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+		)
+	endif()
+endif()
+
+get_filename_component(
+	PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}"
+)
+if(NOT EXISTS ${PICO_SDK_PATH})
+	message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if(NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+	message(
+		FATAL_ERROR
+			"Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK"
+	)
+endif()
+
+set(PICO_SDK_PATH
+	${PICO_SDK_PATH}
+	CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE
+)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,17 @@
+# In order to use this library in your own cmake based project, you can use the
+# following
+# ~~~
+# pico_sdk_init()
+# include(FetchContent)
+#
+# FetchContent_Declare(can2040
+#   GIT_REPOSITORY https://github.com/KevinOConnor/can2040.git
+#   SOURCE_SUBDIR cmake)
+# FetchContent_MakeAvailable(can2040)
+# ~~~
+
+add_executable(simple simple.c)
+
+target_link_libraries(simple pico_stdlib can2040::can2040)
+
+pico_add_extra_outputs(simple)

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,0 +1,49 @@
+#include <hardware/irq.h>
+#include <hardware/regs/intctrl.h>
+#include <pico/stdlib.h>
+#include <stdio.h>
+
+#include "can2040.h"
+
+static struct can2040 cbus;
+
+static void
+can2040_cb(struct can2040 *cd, uint32_t notify, struct can2040_msg *msg)
+{
+    // This is an example, but do not do heavy operation while in callback
+    printf ("got new event %d, with message %d\n",notify,msg->id);
+}
+
+static void
+PIOx_IRQHandler(void)
+{
+    can2040_pio_irq_handler(&cbus);
+}
+
+void
+canbus_setup(void)
+{
+    uint32_t pio_num = 0;
+    uint32_t sys_clock = SYS_CLK_HZ, bitrate = 500000;
+    uint32_t gpio_rx = 4, gpio_tx = 5;
+
+    // Setup canbus
+    can2040_setup(&cbus, pio_num);
+    can2040_callback_config(&cbus, can2040_cb);
+
+    // Enable irqs
+    irq_set_exclusive_handler(PIO0_IRQ_0, PIOx_IRQHandler);
+    irq_set_priority(PIO0_IRQ_0, 1);
+    irq_set_enabled(PIO0_IRQ_0,true);
+
+    // Start canbus
+    can2040_start(&cbus, sys_clock, bitrate, gpio_rx, gpio_tx);
+}
+
+
+int main() {
+	canbus_setup();
+	while(true) {
+	}
+	return 0;
+}


### PR DESCRIPTION
Knowning exactly what to do to use can2040 in a project can be a bit hairy.

This provide a CMakeLists file that is compatible with the pico C/C++ sdk to build the library. It is compatible with FetchContent.

Therefore including can2040 in a project can be done with 

```cmake

pico_sdk_init()

FetchContent_Declare(can2040
GIT_REPOSITORY https://github.com/KevinOConnor/can2040.git
GIT_TAG master)
FetchContent_MakeAvailable(can2040)
add_executable(myprog)
target_link_libraries(myprog can2040::can2040)
```