### PR TITLE
No need to include cmsis_gcc.h header

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -44,7 +44,7 @@ void
 canbus_setup(void)
 {
     uint32_t pio_num = 0;
-    uint32_t sys_clock = 125000000, bitrate = 500000;
+    uint32_t sys_clock = SYS_CLK_HZ, bitrate = 500000;
     uint32_t gpio_rx = 4, gpio_tx = 5;
 
     // Setup canbus
@@ -52,9 +52,9 @@ canbus_setup(void)
     can2040_callback_config(&cbus, can2040_cb);
 
     // Enable irqs
-    irq_set_exclusive_handler(PIO0_IRQ_0_IRQn, PIOx_IRQHandler);
-    NVIC_SetPriority(PIO0_IRQ_0_IRQn, 1);
-    NVIC_EnableIRQ(PIO0_IRQ_0_IRQn);
+    irq_set_exclusive_handler(PIO0_IRQ_0, PIOx_IRQHandler);
+    irq_set_priority(PIO0_IRQ_0, 1);
+    irq_set_enabled(PIO0_IRQ_0, 1);
 
     // Start canbus
     can2040_start(&cbus, sys_clock, bitrate, gpio_rx, gpio_tx);

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,7 +15,7 @@ The code depends on a few files from the
 [pico sdk](https://github.com/raspberrypi/pico-sdk.git) (version
 1.3.0 or later) that must be in the include path when compiling
 can2040.  For example:
-`arm-none-eabi-gcc -O2 -I/path/to/sdk/src/rp2040/ -I/path/to/sdk/src/rp2_common/cmsis/stub/CMSIS/Device/RaspberryPi/RP2040/Include/ ...`
+`arm-none-eabi-gcc -O2 -I/path/to/sdk/src/rp2040/ ...`
 
 If compiling for the rp2350 then pico_sdk version 2.0.0 or later is
 required and the compiler flags must include `-DPICO_RP2350` (the

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -1,13 +1,12 @@
 // Software CANbus implementation for rp2040
 //
-// Copyright (C) 2022-2024  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2022-2025  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
 #include <stdint.h> // uint32_t
 #include <string.h> // memset
 #include "can2040.h" // can2040_setup
-#include "cmsis_gcc.h" // __DMB
 #include "hardware/regs/dreq.h" // DREQ_PIO0_RX1
 #include "hardware/structs/dma.h" // dma_hw
 #include "hardware/structs/iobank0.h" // iobank0_hw
@@ -33,6 +32,7 @@
 #define unlikely(x)     __builtin_expect(!!(x), 0)
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #define DIV_ROUND_UP(n,d) (((n) + (d) - 1) / (d))
+#define __DMB() __asm__ __volatile__("dmb 0xF": : :"memory")
 
 // Helper functions for writing to "io" memory
 static inline void writel(void *addr, uint32_t val) {


### PR DESCRIPTION
That header is only needed for the __DMB() definition and it is easy enough to include that definition directly in the code.  This simplifies the build requirements.

This has been raised a couple of times before (eg, #66).

-Kevin