### PR TITLE
Support a "silent mode" with no "gpio_tx" line

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -156,7 +156,7 @@ their callback function.
 
 ## can2040_start
 
-`void can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate, uint32_t gpio_rx, uint32_t gpio_tx)`
+`void can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate, int32_t gpio_rx, int32_t gpio_tx)`
 
 This function starts the main can2040 CAN bus implementation.  The
 provided GPIO pins will be configured and associated with the
@@ -176,11 +176,19 @@ and 47 (for GPIO16 to GPIO47) if both `gpio_rx` and `gpio_tx` are
 between 16 and 47.
 
 The `gpio_tx` parameter specifies the gpio number that is routed to
-the "CAN TX" pin of the CAN bus transceiver.  On rp2040 chips it
-should be between 0 and 29 (for GPIO0 to GPIO29).  On the rp2350 chips
-it may be between 0 and 31 (for GPIO0 to GPIO31), or alternatively
-between 16 and 47 (for GPIO16 to GPIO47) if both `gpio_rx` and
-`gpio_tx` are between 16 and 47.
+the "CAN TX" pin of the CAN bus transceiver (or to `-1` to disable
+transmissions).  On rp2040 chips it should be between 0 and 29 (for
+GPIO0 to GPIO29).  On the rp2350 chips it may be between 0 and 31 (for
+GPIO0 to GPIO31), or alternatively between 16 and 47 (for GPIO16 to
+GPIO47) if both `gpio_rx` and `gpio_tx` are between 16 and 47.
+
+If `gpio_tx` is set to a `-1` then can2040 will run in a "silent
+mode".  That is, it will not transmit or acknowledge messages, but it
+can still report messages successfully sent, received, and
+acknowledged by other nodes on the bus.  If this facility is used, it
+is the caller's responsibility to ensure the canbus transceiver
+hardware is in a recessive transmit state (ie, the actual "gpio_tx"
+wire going to the canbus transceiver should be set to a "high" state).
 
 After calling this function, activity on the CAN bus may result in the
 user specified `can2040_rx_cb` callback being invoked.

--- a/src/can2040.c
+++ b/src/can2040.c
@@ -1,6 +1,6 @@
-// Software CANbus implementation for rp2040
+// Software CANbus implementation for rp2040/rp2350
 //
-// Copyright (C) 2022-2025  Kevin O'Connor <kevin@koconnor.net>
+// Copyright (C) 2022-2026  Kevin O'Connor <kevin@koconnor.net>
 //
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
@@ -213,10 +213,13 @@ pio_tx_setup(struct can2040 *cd)
         | can2040_offset_tx_conflict << PIO_SM0_EXECCTRL_WRAP_BOTTOM_LSB);
     sm->shiftctrl = (PIO_SM0_SHIFTCTRL_FJOIN_TX_BITS
                      | PIO_SM0_SHIFTCTRL_AUTOPULL_BITS);
-    sm->pinctrl = (1 << PIO_SM0_PINCTRL_SET_COUNT_LSB
+    uint32_t pinctrl = 0;
+    if (cd->gpio_tx >= 0)
+        pinctrl = (1 << PIO_SM0_PINCTRL_SET_COUNT_LSB
                    | 1 << PIO_SM0_PINCTRL_OUT_COUNT_LSB
                    | gpio_tx << PIO_SM0_PINCTRL_SET_BASE_LSB
                    | gpio_tx << PIO_SM0_PINCTRL_OUT_BASE_LSB);
+    sm->pinctrl = pinctrl;
     sm->instr = 0xe001; // set pins, 1
     sm->instr = 0xe081; // set pindirs, 1
 }
@@ -430,7 +433,8 @@ pio_setup(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate)
     // Map Rx/Tx gpios
     uint32_t pio_func = 6 + cd->pio_num;
     rp2040_gpio_peripheral(cd->gpio_rx, pio_func, 1);
-    rp2040_gpio_peripheral(cd->gpio_tx, pio_func, 0);
+    if (cd->gpio_tx >= 0)
+        rp2040_gpio_peripheral(cd->gpio_tx, pio_func, 0);
 }
 
 
@@ -1349,7 +1353,7 @@ can2040_check_transmit(struct can2040 *cd)
     uint32_t tx_pull_pos = readl(&cd->tx_pull_pos);
     uint32_t tx_push_pos = cd->tx_push_pos;
     uint32_t pending = tx_push_pos - tx_pull_pos;
-    return pending < ARRAY_SIZE(cd->tx_queue);
+    return pending < ARRAY_SIZE(cd->tx_queue) && cd->gpio_tx >= 0;
 }
 
 // API function to transmit a message
@@ -1359,7 +1363,7 @@ can2040_transmit(struct can2040 *cd, struct can2040_msg *msg)
     uint32_t tx_pull_pos = readl(&cd->tx_pull_pos);
     uint32_t tx_push_pos = cd->tx_push_pos;
     uint32_t pending = tx_push_pos - tx_pull_pos;
-    if (pending >= ARRAY_SIZE(cd->tx_queue))
+    if (pending >= ARRAY_SIZE(cd->tx_queue) || cd->gpio_tx < 0)
         // Tx queue full
         return -1;
 
@@ -1448,8 +1452,11 @@ can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb)
 // API function to start CANbus interface
 void
 can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate
-              , uint32_t gpio_rx, uint32_t gpio_tx)
+              , int32_t gpio_rx, int32_t gpio_tx)
 {
+    if (IS_RP2350 && ((gpio_rx < 16 && gpio_tx > 31)
+                      || (gpio_rx > 31 && gpio_tx < 16)))
+        gpio_tx = -1;
     cd->gpio_rx = gpio_rx;
     cd->gpio_tx = gpio_tx;
     data_state_clear_bits(cd);

--- a/src/can2040.h
+++ b/src/can2040.h
@@ -35,7 +35,7 @@ struct can2040_stats {
 void can2040_setup(struct can2040 *cd, uint32_t pio_num);
 void can2040_callback_config(struct can2040 *cd, can2040_rx_cb rx_cb);
 void can2040_start(struct can2040 *cd, uint32_t sys_clock, uint32_t bitrate
-                   , uint32_t gpio_rx, uint32_t gpio_tx);
+                   , int32_t gpio_rx, int32_t gpio_tx);
 void can2040_stop(struct can2040 *cd);
 void can2040_get_statistics(struct can2040 *cd, struct can2040_stats *stats);
 void can2040_pio_irq_handler(struct can2040 *cd);
@@ -61,7 +61,7 @@ struct can2040 {
     // Setup
     uint32_t pio_num;
     void *pio_hw;
-    uint32_t gpio_rx, gpio_tx;
+    int32_t gpio_rx, gpio_tx;
     can2040_rx_cb rx_cb;
     struct can2040_stats stats;
 


### PR DESCRIPTION
This PR makes it possible to call can2040_start() with gpio_tx=-1 .  In this situation, the gpio_tx pin will not be configured and it will not be possible to transmit messages.

It should still be possible to receive messages however.  This may be useful to implement a "silent mode" (aka "listen only" mode).

I don't immediately have a good setup to test this, so it would be great if others would be able to check if it behaves as expected.

Cheers,
-Kevin